### PR TITLE
Script reassings internal migration individuals 

### DIFF
--- a/scripts/reassign_internal_migration.py
+++ b/scripts/reassign_internal_migration.py
@@ -2,6 +2,7 @@
 import os
 import pandas as pd
 import argparse
+from glob import glob
 pd.options.mode.chained_assignment = None
 
 columns_dtypes = {'tracked': 'bool', 'immigrated': 'str', 'emigrated': 'str', 'cause_of_death': 'str',
@@ -11,7 +12,7 @@ columns_dtypes = {'tracked': 'bool', 'immigrated': 'str', 'emigrated': 'str', 'c
           'entrance_time': 'str', 'parent_id': 'int64', 'last_birth_time': 'str', 'age_bucket': 'str'}
 
 
-def reassing_internal_migration_to_LAD(location, input_path, pool_migrants):
+def reassign_internal_migration_to_LAD(location, input_path, pool_migrants):
     """ Function that finds all the individuals that internally migrated into a given location
 
     Parameters
@@ -77,7 +78,7 @@ def reassing_internal_migration_to_LAD(location, input_path, pool_migrants):
                                         final_file+'_reassigned.csv'))
 
 
-def reassing_all(input_data_dir):
+def reassign_all(input_data_dir, startswith = 'E'):
     """
     Run reassigment in all existing locations present in an input directory
 
@@ -85,19 +86,24 @@ def reassing_all(input_data_dir):
     ----------
     input_data_dir : string
         Input data path where the outputs of all simulations are found
+    startswith: string
+        Prefix after the directory to be used
+
     Returns:
     ----------
         A dictionary of dataframes with the pool of migrants for each year.
     """
 
-    list_pop_locations_dir = [i for i in os.listdir(input_data_dir) if i.startswith('E')]
+    # TODO: Change to glob
+    list_pop_locations_dir = [i for i in os.listdir(input_data_dir) if i.startswith(startswith)]
+
 
     pool_migrants = get_migrants(input_data_dir, list_pop_locations_dir)
 
     for location in list_pop_locations_dir:
         print ()
         print('Running re-assigment for: ', location)
-        reassing_internal_migration_to_LAD(location, input_data_dir, pool_migrants)
+        reassign_internal_migration_to_LAD(location, input_data_dir, pool_migrants)
 
 
 def get_migrants(input_path, list_pop_locations_dir):
@@ -170,6 +176,6 @@ if __name__ == "__main__":
     if args.location:
         list_pop_locations_dir = [i for i in os.listdir(args.input_data_dir) if i.startswith('E')]
         pool_migrants = get_migrants(args.input_data_dir, list_pop_locations_dir)
-        reassing_internal_migration_to_LAD(args.location, args.input_data_dir, pool_migrants)
+        reassign_internal_migration_to_LAD(args.location, args.input_data_dir, pool_migrants)
     else:
-        reassing_all(args.input_data_dir)
+        reassign_all(args.input_data_dir)

--- a/scripts/reassing_internal_migration.py
+++ b/scripts/reassing_internal_migration.py
@@ -4,8 +4,8 @@ import pandas as pd
 import argparse
 
 
-def reassing_internal_migration(location, input_path, list_pop_locations_dir):
-    """ Function that run the ONS-Simmulation comparisons for a given location
+def reassing_internal_migration_to_LAD(location, input_path, list_pop_locations_dir):
+    """ Function that finds all the individuals that internally migrated into a given location
 
     Parameters
     ----------
@@ -22,8 +22,9 @@ def reassing_internal_migration(location, input_path, list_pop_locations_dir):
     # path to the simulation files
     list_pop_dir = [i for i in os.listdir(input_location_path) if i.startswith('year_')]
 
-    # for each year run the comparisons
+    # for each year run the reassigment
     for year_dir in list_pop_dir:
+        print ('Reassign for :', year_dir)
 
         simulation_data = pd.read_csv(os.path.join(input_location_path, year_dir,
                                                    'ssm_' + location + '_MSOA11_ppp_2011_simulation_' + year_dir + '.csv'))
@@ -31,6 +32,7 @@ def reassing_internal_migration(location, input_path, list_pop_locations_dir):
         simulation_data['duplicate'] = False
         simulation_data['internal_migration_in'] = 'No'
 
+        # look in each location finding the individuals that migrated
         for loc in list_pop_locations_dir:
             if loc==location:
                 continue
@@ -52,8 +54,9 @@ def reassing_internal_migration(location, input_path, list_pop_locations_dir):
     # run comparison for the total simmulation
     final_file = 'ssm_' + location + '_MSOA11_ppp_2011_simulation.csv'
 
-    simulation_data = pd.read_csv(os.path.join(input_location_path, final_file))
+    simulation_data = pd.read_csv(os.path.join(input_location_path, final_file),low_memory=False)
 
+    print('Reassign full dataset ')
     for loc in list_pop_locations_dir:
         data_location_simulation = pd.read_csv(os.path.join(input_path, loc,
                                                             'ssm_' + loc + '_MSOA11_ppp_2011_simulation.csv'))
@@ -64,13 +67,13 @@ def reassing_internal_migration(location, input_path, list_pop_locations_dir):
 
         simulation_data = pd.concat([simulation_data, data_location_simulation])
 
-    simulation_data.to_csv(os.path.join(input_location_path, year_dir,
-                                        'ssm_' + location + '_MSOA11_ppp_2011_simulation_reassigned.csv'))
+    simulation_data.to_csv(os.path.join(input_location_path,
+                                        final_file+'_reassigned.csv'))
 
 
-def run_all_validations(input_data_dir):
+def reassing_all(input_data_dir):
     """
-    Run validation comparison in all existing locations present in an input directory
+    Run reassigment in all existing locations present in an input directory
 
     input_data_dir : string
         Input data path where the outputs of all simulations are found
@@ -79,8 +82,9 @@ def run_all_validations(input_data_dir):
     list_pop_locations_dir = [i for i in os.listdir(input_data_dir) if i.startswith('E')]
 
     for location in list_pop_locations_dir:
+        print ()
         print('Running re-assigment for: ', location)
-        reassing_internal_migration(location, input_data_dir, list_pop_locations_dir)
+        reassing_internal_migration_to_LAD(location, input_data_dir, list_pop_locations_dir)
 
 
 if __name__ == "__main__":
@@ -93,6 +97,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.location:
         list_pop_locations_dir = [i for i in os.listdir(args.input_data_dir) if i.startswith('E')]
-        reassing_internal_migration(args.location, args.input_data_dir, list_pop_locations_dir)
+        reassing_internal_migration_to_LAD(args.location, args.input_data_dir, list_pop_locations_dir)
     else:
-        run_all_validations(args.input_data_dir)
+        reassing_all(args.input_data_dir)

--- a/scripts/reassing_internal_migration.py
+++ b/scripts/reassing_internal_migration.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+import os
+import pandas as pd
+import argparse
+
+
+def reassing_internal_migration(location, input_path, list_pop_locations_dir):
+    """ Function that run the ONS-Simmulation comparisons for a given location
+
+    Parameters
+    ----------
+    location: str
+        LAD code for place to run the simulation
+    input_path: str
+        Input data path where the outputs of all simulations are found
+    list_pop_locations_dir:
+        list of other locations where to search for internal migration
+
+    """
+
+    input_location_path = os.path.join(input_path, location)
+    # path to the simulation files
+    list_pop_dir = [i for i in os.listdir(input_location_path) if i.startswith('year_')]
+
+    # for each year run the comparisons
+    for year_dir in list_pop_dir:
+
+        simulation_data = pd.read_csv(os.path.join(input_location_path, year_dir,
+                                                   'ssm_' + location + '_MSOA11_ppp_2011_simulation_' + year_dir + '.csv'))
+
+        simulation_data['duplicate'] = False
+        simulation_data['internal_migration_in'] = 'No'
+
+        for loc in list_pop_locations_dir:
+            if loc==location:
+                continue
+            data_location_simulation = pd.read_csv(os.path.join(input_path, loc, year_dir,
+                                                                'ssm_' + loc + '_MSOA11_ppp_2011_simulation_' + year_dir + '.csv'))
+
+            data_location_simulation = data_location_simulation[data_location_simulation['location'] == location]
+
+            if data_location_simulation.shape[0]>0:
+                print ('Reassign ',data_location_simulation.shape[0],' individuals that migrated from ',loc,' to ',location)
+                data_location_simulation['duplicate'] = True
+                data_location_simulation['internal_migration_in'] = 'Yes'
+
+                simulation_data = pd.concat([simulation_data,data_location_simulation])
+
+        simulation_data.to_csv(os.path.join(input_location_path, year_dir,
+                                            'ssm_' + location + '_MSOA11_ppp_2011_simulation_' + year_dir + '_reassigned.csv'))
+
+    # run comparison for the total simmulation
+    final_file = 'ssm_' + location + '_MSOA11_ppp_2011_simulation.csv'
+
+    simulation_data = pd.read_csv(os.path.join(input_location_path, final_file))
+
+    for loc in list_pop_locations_dir:
+        data_location_simulation = pd.read_csv(os.path.join(input_path, loc,
+                                                            'ssm_' + loc + '_MSOA11_ppp_2011_simulation.csv'))
+
+        data_location_simulation = data_location_simulation[data_location_simulation['location'] == location]
+        data_location_simulation['duplicate'] = True
+        data_location_simulation['internal_migration_in'] = 'Yes'
+
+        simulation_data = pd.concat([simulation_data, data_location_simulation])
+
+    simulation_data.to_csv(os.path.join(input_location_path, year_dir,
+                                        'ssm_' + location + '_MSOA11_ppp_2011_simulation_reassigned.csv'))
+
+
+def run_all_validations(input_data_dir):
+    """
+    Run validation comparison in all existing locations present in an input directory
+
+    input_data_dir : string
+        Input data path where the outputs of all simulations are found
+    """
+
+    list_pop_locations_dir = [i for i in os.listdir(input_data_dir) if i.startswith('E')]
+
+    for location in list_pop_locations_dir:
+        print('Running re-assigment for: ', location)
+        reassing_internal_migration(location, input_data_dir, list_pop_locations_dir)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Reassign internal migrants to their new location for validation purposes")
+
+    parser.add_argument('--input_data_dir', help='directory where the input data is', default=None)
+    parser.add_argument('--location', help='LAD code (in case you want to run a specific location)', default=None)
+
+    args = parser.parse_args()
+    if args.location:
+        list_pop_locations_dir = [i for i in os.listdir(args.input_data_dir) if i.startswith('E')]
+        reassing_internal_migration(args.location, args.input_data_dir, list_pop_locations_dir)
+    else:
+        run_all_validations(args.input_data_dir)

--- a/scripts/reassing_internal_migration.py
+++ b/scripts/reassing_internal_migration.py
@@ -58,6 +58,8 @@ def reassing_internal_migration_to_LAD(location, input_path, list_pop_locations_
 
     print('Reassign full dataset ')
     for loc in list_pop_locations_dir:
+        if loc == location:
+            continue
         data_location_simulation_full = pd.read_csv(os.path.join(input_path, loc,
                                                             'ssm_' + loc + '_MSOA11_ppp_2011_simulation.csv'))
 

--- a/scripts/reassing_internal_migration.py
+++ b/scripts/reassing_internal_migration.py
@@ -2,6 +2,13 @@
 import os
 import pandas as pd
 import argparse
+pd.options.mode.chained_assignment = None
+
+columns_dtypes = {'tracked': 'bool', 'immigrated': 'str', 'emigrated': 'str', 'cause_of_death': 'str',
+          'years_of_life_lost': 'float64', 'previous_MSOA_locations': 'str', 'internal_outmigration': 'str',
+          'last_outmigration_time': 'str', 'previous_LAD_locations': 'str', 'ethnicity': 'str', 'age': 'float64',
+          'MSOA': 'str', 'alive': 'str', 'sex': 'float64', 'location': 'str', 'exit_time': 'str',
+          'entrance_time': 'str', 'parent_id': 'int64', 'last_birth_time': 'str', 'age_bucket': 'str'}
 
 
 def reassing_internal_migration_to_LAD(location, input_path, pool_migrants):
@@ -27,10 +34,10 @@ def reassing_internal_migration_to_LAD(location, input_path, pool_migrants):
         print ('Reassign for ', year_dir)
 
         simulation_data = pd.read_csv(os.path.join(input_location_path, year_dir,
-                                                   'ssm_' + location + '_MSOA11_ppp_2011_simulation_' + year_dir + '.csv'))
+                                                   'ssm_' + location + '_MSOA11_ppp_2011_simulation_' + year_dir + '.csv'), dtype=columns_dtypes)
 
-        simulation_data['duplicate'] = False
-        simulation_data['internal_migration_in'] = 'No'
+        simulation_data.loc[:,'duplicate'] = False
+        simulation_data.loc[:,'internal_migration_in'] = 'No'
 
 
         data_location_simulation = pool_migrants[year_dir]
@@ -39,8 +46,8 @@ def reassing_internal_migration_to_LAD(location, input_path, pool_migrants):
 
         if data_location_simulation.shape[0]>0:
             print ('Reassign ',data_location_simulation.shape[0],' individuals that migrated to ',location)
-            data_location_simulation['duplicate'] = True
-            data_location_simulation['internal_migration_in'] = 'Yes'
+            data_location_simulation.loc[:,'duplicate'] = True
+            data_location_simulation.loc[:,'internal_migration_in'] = 'Yes'
 
             simulation_data = pd.concat([simulation_data,data_location_simulation])
 
@@ -51,7 +58,7 @@ def reassing_internal_migration_to_LAD(location, input_path, pool_migrants):
     final_file = 'ssm_' + location + '_MSOA11_ppp_2011_simulation.csv'
 
     simulation_data_full = pd.read_csv(os.path.join(input_location_path,
-                                                   'ssm_' + location + '_MSOA11_ppp_2011_simulation.csv'))
+                                                   'ssm_' + location + '_MSOA11_ppp_2011_simulation.csv'), dtype=columns_dtypes)
 
     data_location_simulation_full = pool_migrants['full']
 
@@ -61,8 +68,8 @@ def reassing_internal_migration_to_LAD(location, input_path, pool_migrants):
         print ('Full dataset')
         print('Reassign ', data_location_simulation_full.shape[0], ' individuals that migrated from  to ', location)
 
-        data_location_simulation_full['duplicate'] = True
-        data_location_simulation_full['internal_migration_in'] = 'Yes'
+        data_location_simulation_full.loc[:,'duplicate'] = True
+        data_location_simulation_full.loc[:,'internal_migration_in'] = 'Yes'
 
         simulation_data_full = pd.concat([simulation_data_full, data_location_simulation_full])
 
@@ -125,27 +132,21 @@ def get_migrants(input_path, list_pop_locations_dir):
         for loc in list_pop_locations_dir:
 
             data_location_simulation = pd.read_csv(os.path.join(input_path, loc, year_dir,
-                                                                'ssm_' + loc + '_MSOA11_ppp_2011_simulation_' + year_dir + '.csv'))
+                                                                'ssm_' + loc + '_MSOA11_ppp_2011_simulation_' + year_dir + '.csv'), dtype=columns_dtypes)
 
             data_location_simulation_int_migrants = data_location_simulation[data_location_simulation['location'] != loc]
 
             if data_location_simulation_int_migrants.shape[0]>0:
-                print ('Found ',data_location_simulation.shape[0],' individuals that migrated' )
-                data_location_simulation_int_migrants['duplicate'] = True
-                data_location_simulation_int_migrants['internal_migration_in'] = 'Yes'
-
+                print ('Found ',data_location_simulation_int_migrants.shape[0],' individuals that migrated' )
                 migrant_data = pd.concat([migrant_data,data_location_simulation_int_migrants])
 
             if year_dir == list_pop_dir[-1]:
                 data_location_simulation_full = pd.read_csv(os.path.join(input_path, loc,
-                                                                         'ssm_' + loc + '_MSOA11_ppp_2011_simulation.csv'))
+                                                                         'ssm_' + loc + '_MSOA11_ppp_2011_simulation.csv'), dtype=columns_dtypes)
 
                 data_location_simulation_full_migrants = data_location_simulation_full[data_location_simulation_full['location'] != loc]
                 if data_location_simulation_full_migrants.shape[0] > 0:
                     print('Found ', data_location_simulation_full_migrants.shape[0], ' individuals that migrated')
-                    data_location_simulation_full_migrants['duplicate'] = True
-                    data_location_simulation_full_migrants['internal_migration_in'] = 'Yes'
-
                     full_migrant_data = pd.concat([full_migrant_data, data_location_simulation_full_migrants])
 
         dict_migrants[year_dir] = migrant_data

--- a/scripts/reassing_internal_migration.py
+++ b/scripts/reassing_internal_migration.py
@@ -4,7 +4,7 @@ import pandas as pd
 import argparse
 
 
-def reassing_internal_migration_to_LAD(location, input_path, list_pop_locations_dir):
+def reassing_internal_migration_to_LAD(location, input_path, pool_migrants):
     """ Function that finds all the individuals that internally migrated into a given location
 
     Parameters
@@ -13,8 +13,8 @@ def reassing_internal_migration_to_LAD(location, input_path, list_pop_locations_
         LAD code for place to run the simulation
     input_path: str
         Input data path where the outputs of all simulations are found
-    list_pop_locations_dir:
-        list of other locations where to search for internal migration
+    pool_migrants: dict of Dataframe
+        Dictionary with pool of migrants from each year
 
     """
 
@@ -32,21 +32,17 @@ def reassing_internal_migration_to_LAD(location, input_path, list_pop_locations_
         simulation_data['duplicate'] = False
         simulation_data['internal_migration_in'] = 'No'
 
-        # look in each location finding the individuals that migrated
-        for loc in list_pop_locations_dir:
-            if loc==location:
-                continue
-            data_location_simulation = pd.read_csv(os.path.join(input_path, loc, year_dir,
-                                                                'ssm_' + loc + '_MSOA11_ppp_2011_simulation_' + year_dir + '.csv'))
 
-            data_location_simulation = data_location_simulation[data_location_simulation['location'] == location]
+        data_location_simulation = pool_migrants[year_dir]
 
-            if data_location_simulation.shape[0]>0:
-                print ('Reassign ',data_location_simulation.shape[0],' individuals that migrated from ',loc,' to ',location)
-                data_location_simulation['duplicate'] = True
-                data_location_simulation['internal_migration_in'] = 'Yes'
+        data_location_simulation = data_location_simulation[data_location_simulation['location'] == location]
 
-                simulation_data = pd.concat([simulation_data,data_location_simulation])
+        if data_location_simulation.shape[0]>0:
+            print ('Reassign ',data_location_simulation.shape[0],' individuals that migrated to ',location)
+            data_location_simulation['duplicate'] = True
+            data_location_simulation['internal_migration_in'] = 'Yes'
+
+            simulation_data = pd.concat([simulation_data,data_location_simulation])
 
         simulation_data.to_csv(os.path.join(input_location_path, year_dir,
                                             'ssm_' + location + '_MSOA11_ppp_2011_simulation_' + year_dir + '_reassigned.csv'))
@@ -54,25 +50,21 @@ def reassing_internal_migration_to_LAD(location, input_path, list_pop_locations_
     # run comparison for the total simmulation
     final_file = 'ssm_' + location + '_MSOA11_ppp_2011_simulation.csv'
 
-    simulation_data_full = pd.read_csv(os.path.join(input_location_path, final_file),low_memory=False)
+    simulation_data_full = pd.read_csv(os.path.join(input_location_path,
+                                                   'ssm_' + location + '_MSOA11_ppp_2011_simulation.csv'))
 
-    print('Reassign full dataset ')
-    for loc in list_pop_locations_dir:
-        if loc == location:
-            continue
-        data_location_simulation_full = pd.read_csv(os.path.join(input_path, loc,
-                                                            'ssm_' + loc + '_MSOA11_ppp_2011_simulation.csv'))
+    data_location_simulation_full = pool_migrants['full']
 
-        data_location_simulation_full = data_location_simulation_full[data_location_simulation_full['location'] == location]
+    data_location_simulation_full = data_location_simulation_full[data_location_simulation_full['location'] == location]
 
-        if data_location_simulation_full.shape[0] > 0:
+    if data_location_simulation_full.shape[0] > 0:
+        print ('Full dataset')
+        print('Reassign ', data_location_simulation_full.shape[0], ' individuals that migrated from  to ', location)
 
-            print('Reassign ', data_location_simulation_full.shape[0], ' individuals that migrated from ', loc, ' to ', location)
+        data_location_simulation_full['duplicate'] = True
+        data_location_simulation_full['internal_migration_in'] = 'Yes'
 
-            data_location_simulation_full['duplicate'] = True
-            data_location_simulation_full['internal_migration_in'] = 'Yes'
-
-            simulation_data_full = pd.concat([simulation_data_full, data_location_simulation_full])
+        simulation_data_full = pd.concat([simulation_data_full, data_location_simulation_full])
 
     simulation_data_full.to_csv(os.path.join(input_location_path,
                                         final_file+'_reassigned.csv'))
@@ -82,16 +74,88 @@ def reassing_all(input_data_dir):
     """
     Run reassigment in all existing locations present in an input directory
 
+    Parameters:
+    ----------
     input_data_dir : string
         Input data path where the outputs of all simulations are found
+    Returns:
+    ----------
+        A dictionary of dataframes with the pool of migrants for each year.
     """
 
     list_pop_locations_dir = [i for i in os.listdir(input_data_dir) if i.startswith('E')]
 
+    pool_migrants = get_migrants(input_data_dir, list_pop_locations_dir)
+
     for location in list_pop_locations_dir:
         print ()
         print('Running re-assigment for: ', location)
-        reassing_internal_migration_to_LAD(location, input_data_dir, list_pop_locations_dir)
+        reassing_internal_migration_to_LAD(location, input_data_dir, pool_migrants)
+
+
+def get_migrants(input_path, list_pop_locations_dir):
+    """ Function that finds all the individuals that internally migrated into a given location
+
+    Parameters
+    ----------
+    location: str
+        LAD code for place to run the simulation
+    input_path: str
+        Input data path where the outputs of all simulations are found
+    list_pop_locations_dir:
+        list of other locations where to search for internal migration
+
+    """
+
+    input_location_path = os.path.join(input_path, list_pop_locations_dir[0])
+    # path to the simulation files
+    list_pop_dir = [i for i in os.listdir(input_location_path) if i.startswith('year_')]
+
+    dict_migrants = {}
+    # for each year run the reassigment
+    for year_dir in list_pop_dir:
+        print ('Get migrants for ', year_dir)
+
+        migrant_data = pd.DataFrame()
+        # look in each location finding the individuals that migrated
+
+        if year_dir == list_pop_dir[-1]:
+            full_migrant_data= pd.DataFrame()
+
+        for loc in list_pop_locations_dir:
+
+            data_location_simulation = pd.read_csv(os.path.join(input_path, loc, year_dir,
+                                                                'ssm_' + loc + '_MSOA11_ppp_2011_simulation_' + year_dir + '.csv'))
+
+            data_location_simulation_int_migrants = data_location_simulation[data_location_simulation['location'] != loc]
+
+            if data_location_simulation_int_migrants.shape[0]>0:
+                print ('Found ',data_location_simulation.shape[0],' individuals that migrated' )
+                data_location_simulation_int_migrants['duplicate'] = True
+                data_location_simulation_int_migrants['internal_migration_in'] = 'Yes'
+
+                migrant_data = pd.concat([migrant_data,data_location_simulation_int_migrants])
+
+            if year_dir == list_pop_dir[-1]:
+                data_location_simulation_full = pd.read_csv(os.path.join(input_path, loc,
+                                                                         'ssm_' + loc + '_MSOA11_ppp_2011_simulation.csv'))
+
+                data_location_simulation_full_migrants = data_location_simulation_full[data_location_simulation_full['location'] != loc]
+                if data_location_simulation_full_migrants.shape[0] > 0:
+                    print('Found ', data_location_simulation_full_migrants.shape[0], ' individuals that migrated')
+                    data_location_simulation_full_migrants['duplicate'] = True
+                    data_location_simulation_full_migrants['internal_migration_in'] = 'Yes'
+
+                    full_migrant_data = pd.concat([full_migrant_data, data_location_simulation_full_migrants])
+
+        dict_migrants[year_dir] = migrant_data
+
+        if year_dir == list_pop_dir[-1]:
+            dict_migrants['full'] = full_migrant_data
+
+    # run comparison for the total simmulation
+    return dict_migrants
+
 
 
 if __name__ == "__main__":
@@ -104,6 +168,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.location:
         list_pop_locations_dir = [i for i in os.listdir(args.input_data_dir) if i.startswith('E')]
-        reassing_internal_migration_to_LAD(args.location, args.input_data_dir, list_pop_locations_dir)
+        pool_migrants = get_migrants(args.input_data_dir, list_pop_locations_dir)
+        reassing_internal_migration_to_LAD(args.location, args.input_data_dir, pool_migrants)
     else:
         reassing_all(args.input_data_dir)

--- a/scripts/reassing_internal_migration.py
+++ b/scripts/reassing_internal_migration.py
@@ -24,7 +24,7 @@ def reassing_internal_migration_to_LAD(location, input_path, list_pop_locations_
 
     # for each year run the reassigment
     for year_dir in list_pop_dir:
-        print ('Reassign for :', year_dir)
+        print ('Reassign for ', year_dir)
 
         simulation_data = pd.read_csv(os.path.join(input_location_path, year_dir,
                                                    'ssm_' + location + '_MSOA11_ppp_2011_simulation_' + year_dir + '.csv'))
@@ -54,20 +54,25 @@ def reassing_internal_migration_to_LAD(location, input_path, list_pop_locations_
     # run comparison for the total simmulation
     final_file = 'ssm_' + location + '_MSOA11_ppp_2011_simulation.csv'
 
-    simulation_data = pd.read_csv(os.path.join(input_location_path, final_file),low_memory=False)
+    simulation_data_full = pd.read_csv(os.path.join(input_location_path, final_file),low_memory=False)
 
     print('Reassign full dataset ')
     for loc in list_pop_locations_dir:
-        data_location_simulation = pd.read_csv(os.path.join(input_path, loc,
+        data_location_simulation_full = pd.read_csv(os.path.join(input_path, loc,
                                                             'ssm_' + loc + '_MSOA11_ppp_2011_simulation.csv'))
 
-        data_location_simulation = data_location_simulation[data_location_simulation['location'] == location]
-        data_location_simulation['duplicate'] = True
-        data_location_simulation['internal_migration_in'] = 'Yes'
+        data_location_simulation_full = data_location_simulation_full[data_location_simulation_full['location'] == location]
 
-        simulation_data = pd.concat([simulation_data, data_location_simulation])
+        if data_location_simulation_full.shape[0] > 0:
 
-    simulation_data.to_csv(os.path.join(input_location_path,
+            print('Reassign ', data_location_simulation_full.shape[0], ' individuals that migrated from ', loc, ' to ', location)
+
+            data_location_simulation_full['duplicate'] = True
+            data_location_simulation_full['internal_migration_in'] = 'Yes'
+
+            simulation_data_full = pd.concat([simulation_data_full, data_location_simulation_full])
+
+    simulation_data_full.to_csv(os.path.join(input_location_path,
                                         final_file+'_reassigned.csv'))
 
 


### PR DESCRIPTION
Fixes #9 

- [x] Script that reassigns individuals that internally migrated into a particular LAD.

 - [x] A script that goes through all location directories, and collects the individuals that migrated within all the existing for one LADs
- [x] Created new csv files that includes now migrants that came from other LADs (e.g ssm_E08000032_MSOA11_ppp_2011_simulation_year_2_reassigned.csv)
- [x]   The new csv has now a flag for this individuals with `duplicated` and 'internal_migration'

